### PR TITLE
Create comprehensive user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,16 @@ Demo releases are available through [GitHub](https://github.com/froggey/Mezzano/
 
 These releases are designed to be run in VirtualBox, though QEMU is also supported.
 2GB of RAM, a virtio-net NIC and an Intel HDA audio controller are recommended.
+For instructions on getting started and using Mezzano, please see our [User Documentation](doc/manual.md).
 
 x86-64 images are published.  AArch64 has been made to work on some
 hardware.  But to set expectations: making Mezzano run on any given
 piece of hardware or emulator is still typically a project that
 requires the user to dig into the code.
+
+## Documentation
+
+Comprehensive user documentation, including a getting started guide, user manual, FAQ, and tutorials, can be found in the [doc/manual.md](doc/manual.md) file, which serves as the main entry point for our documentation.
 
 ## Building from source
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,0 +1,69 @@
+# Mezzano - Frequently Asked Questions (FAQ)
+
+This FAQ provides answers to common questions about Mezzano.
+
+**Q: How do I build Mezzano from source?**
+
+A: Mezzano uses a custom build system called MBuild. You can find instructions and the MBuild repository here: [https://github.com/froggey/MBuild](https://github.com/froggey/MBuild). Building from source is recommended for developers or those wishing to contribute. For general use, pre-built images are available (see `getting-started.md`).
+
+**Q: What hardware is supported?**
+
+A: Mezzano is primarily designed for virtualization:
+*   **VirtualBox:** This is the most common way to run Mezzano.
+*   **QEMU:** Also well-supported.
+
+Recommended virtual hardware:
+*   **RAM:** 2GB or more.
+*   **NIC:** Virtio-net is generally recommended. RTL8168 is also supported. The default Intel PRO/1000 series in VirtualBox usually works.
+*   **Audio:** Intel HDA.
+
+**Real Hardware:**
+*   x86-64: Booting from CD/USB on real hardware is possible, but driver support is limited.
+*   AArch64 (ARM64): Has been made to work on some hardware, but setup typically requires significant user effort and code digging.
+*   Consult the `user-manual.md` and `README.md` for more specific details on supported chipsets.
+
+**Q: Where can I get help or support?**
+
+A: The primary place for help, support, and to follow development is the #mezzano IRC channel on Libera Chat (irc.libera.chat).
+
+**Q: How do I save my work in Mezzano?**
+
+A: Mezzano uses a "snapshot" feature. This saves the entire current state of your Mezzano system to disk.
+To take a snapshot:
+1.  Open a REPL (Read-Eval-Print Loop) by pressing `M-F10` (Alt + F10).
+2.  Type the command `(mezzano.supervisor:snapshot)` and press Enter.
+3.  Wait for the yellow status light at the top-left of the screen to turn off.
+When you next boot Mezzano, it will resume from this saved state. See `getting-started.md` or `tutorials.md` for more details.
+
+**Q: What are the "blinkenlights" at the top of the screen?**
+
+A: These are status lights indicating system activity. For a full list and their meanings, please see the "Blinkenlights" section in the `user-manual.md`.
+
+**Q: How do I connect to the internet?**
+
+A: Mezzano has support for networking, primarily with RTL8168 and virtio-net NICs.
+*   Network configuration can be viewed via the Network pane of the "Peek" application.
+*   The default configuration is often specific to VirtualBox's and QEMU's NAT networks.
+*   **Important:** Currently, DHCP is not supported, and bridging to a real network is generally not supported without manual configuration. This means Mezzano might not automatically connect to your local network like other operating systems.
+
+**Q: How do I install new software in Mezzano?**
+
+A: Mezzano has a port of Quicklisp, a Common Lisp library manager. This allows you to download and install many Common Lisp libraries and systems.
+*   You can typically load Quicklisp from the REPL.
+*   For more information on using Quicklisp within Mezzano, refer to any specific notes in the `user-manual.md` or consult the Mezzano community.
+Mezzano does not have a traditional package manager for pre-compiled binary applications like some other operating systems. Software is generally run from source or loaded via Quicklisp.
+
+**Q: How do I quit or shut down Mezzano?**
+
+A: The typical way to "finish" a session is to take a snapshot (see above) and then power off the virtual machine. When you restart, Mezzano will resume from where you left off. There isn't a traditional "shutdown" command that cleans up and powers off in the same way as other operating systems.
+
+**Q: What are some basic applications I can use?**
+
+A: Mezzano comes with several built-in applications. You can usually launch them from the REPL. Some examples include:
+*   **Filer:** A file manager.
+*   **Editor:** A text editor (Emacs-like keybindings).
+*   **Peek:** A system information tool.
+*   **Memory Monitor:** To view memory usage.
+*   **IRC:** An IRC client.
+*   **Telnet:** A Telnet client.
+See the `user-manual.md` for more details on these applications and how to launch them.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,0 +1,69 @@
+# Getting Started with Mezzano
+
+Welcome to Mezzano! This guide will help you take your first steps with this Common Lisp-based operating system.
+
+## 1. Obtaining Mezzano
+
+The easiest way to try Mezzano is by using pre-built demo releases.
+*   **Download:** You can find these on the [Mezzano GitHub Releases page](https://github.com/froggey/Mezzano/releases).
+*   Download the latest `.zip` file (e.g., `Mezzano-Demo4-r2600.zip`).
+*   Extract the archive. You'll find a disk image file (e.g., `Mezzano.vmdk` for VirtualBox or `Mezzano.qcow2` for QEMU).
+
+## 2. Recommended Virtual Machine Setup
+
+Mezzano is primarily designed to be run in a virtual machine. Here are some recommended settings:
+
+*   **Virtualization Software:** VirtualBox (recommended) or QEMU.
+*   **RAM:** At least 2GB.
+*   **NIC (Network Interface Card):**
+    *   For **VirtualBox**, an **Intel PRO/1000 MT Desktop (82540EM)** adapter is a common choice (often the default for Linux VMs).
+    *   For **QEMU**, a `virtio-net` device is generally recommended.
+    *   Mezzano also supports other NICs like RTL8168. For more details on network configuration and supported hardware, please see the `user-manual.md` and `faq.md`.
+*   **Audio Controller:** Intel HDA (High Definition Audio).
+*   **Disk Image:** Use the downloaded Mezzano disk image as the primary hard disk for your VM.
+
+Consult your virtualization software's documentation for instructions on creating a new VM and configuring these settings.
+
+## 3. Your First Boot
+
+Once your VM is configured:
+
+1.  Start the virtual machine.
+2.  Mezzano will boot, and you should see a desktop environment with status lights (blinkenlights) at the top-left.
+
+## 4. Basic Interaction
+
+Here's how to perform some initial actions:
+
+*   **The REPL (Read-Eval-Print Loop):** The REPL is your primary interface for interacting with Mezzano at a low level.
+    *   Press `M-F10` (Alt + F10) to open a new REPL window.
+    *   You'll see a prompt like `CL-USER> `.
+    *   Try a simple Lisp command: type `(+ 2 2)` and press Enter. Mezzano should respond with `4`.
+*   **Windows:**
+    *   You can move windows by clicking and dragging their title bars.
+    *   Alternatively, hold the `Alt` key and click anywhere on a window to drag it.
+    *   To close a window, you can often use `M-F4` (Alt + F4) for the current application, or `C-M-F4` (Ctrl + Alt + F4) to forcibly close it.
+*   **Launching Applications:** Many applications can be launched from the REPL by typing their name (often prefixed with `mezzano.application.` or similar, or a specific launch command). For example, to try and launch the file manager:
+    *   In the REPL, type `(mezzano.gui.filer:spawn)` and press Enter. (Note: The exact command might vary; consult the `user-manual.md` or experiment).
+    *   Similarly, Peek (system information) can often be launched via `(mezzano.gui.peek:spawn)`.
+
+## 5. Saving Your Work: Snapshotting
+
+Mezzano uses a unique system called "snapshotting" to save the entire state of the operating system, including all open applications and data.
+
+1.  **Open a REPL** (if you don't have one open).
+2.  **Type the command:** `(mezzano.supervisor:snapshot)` and press Enter.
+3.  **Wait:** A yellow light will appear in the "blinkenlights" area at the top-left of the screen. Wait for this light to turn off. This indicates the snapshot is complete.
+4.  **Reboot:** You can now safely reboot or power off your VM. When you start Mezzano again, it will resume from the saved snapshot.
+
+This is the primary way to "save your work" in Mezzano.
+
+## 6. Where to Go Next
+
+You've taken your first steps! To learn more about Mezzano:
+
+*   **User Manual (`user-manual.md`):** For detailed information on keybindings, system features, and available applications.
+*   **FAQ (`faq.md`):** For answers to common questions.
+*   **Tutorials (`tutorials.md`):** For step-by-step guides on common tasks.
+
+We hope you enjoy exploring Mezzano!

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1,16 +1,43 @@
-This manual is a work in progress and parts may become outdated as the system changes.
+# Mezzano Operating System Documentation
 
-# Getting Started
+Welcome to the Mezzano documentation. This document serves as a central hub for finding information about using and understanding Mezzano.
 
-See the [quickstart guide](quickstart.md).
+## Core Documents
 
-# Building
+*   **[Getting Started Guide](getting-started.md)**
+    *   New to Mezzano? Start here! This guide covers obtaining Mezzano, setting up your virtual machine, your first boot, and basic interactions.
 
-See [MBuild](https://github.com/froggey/MBuild).
+*   **[User Manual](user-manual.md)**
+    *   The comprehensive guide to using Mezzano. Includes detailed information on:
+        *   Keybindings and shortcuts
+        *   Line editing and editor commands
+        *   System features like snapshotting
+        *   The meaning of the "blinkenlights" status indicators
+        *   Details on built-in applications (Filer, Peek, Editor, etc.)
+        *   Networking information
+        *   Using Swank for Common Lisp development
 
-# Networking
+*   **[Frequently Asked Questions (FAQ)](faq.md)**
+    *   Find answers to common questions about hardware support, building from source, getting help, saving work, and more.
 
-RTL8168 and virtio-net are the only supported NICs.
-The network configuration can be viewed via the Network pane of Peek.
-The default configuration is specific to VirtualBox's and qemu's NAT networks.
-DHCP is not supported and bridging to a real network is not supported.
+*   **[Tutorials](tutorials.md)**
+    *   Step-by-step guides for common tasks, such as:
+        *   Exploring the file system with Filer
+        *   Basic text editing
+        *   Using the REPL (Read-Eval-Print Loop)
+        *   Taking a system snapshot
+
+## For Developers and Contributors
+
+*   **Building Mezzano:**
+    *   Mezzano uses a custom build system called MBuild. See the [MBuild GitHub repository](https://github.com/froggey/MBuild) for instructions.
+*   **Source Code:**
+    *   The Mezzano source code is available on [GitHub](https://github.com/froggey/Mezzano).
+*   **Community:**
+    *   Join the #mezzano IRC channel on Libera Chat (irc.libera.chat) to discuss development and get support.
+
+## Other Information
+
+*   Refer to the main [README.md](../README.md) for a project overview, release information, and major changes between versions.
+
+This documentation is a work in progress and parts may become outdated as the system changes. Contributions and corrections are welcome!

--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -1,0 +1,84 @@
+# Mezzano Tutorials
+
+This document provides step-by-step tutorials for common tasks in Mezzano.
+
+## Tutorial 1: Exploring the File System with Filer
+
+The Filer application allows you to navigate and manage files and directories.
+
+1.  **Open a REPL:** If you don't have one open, press `M-F10` (Alt + F10).
+2.  **Launch Filer:** In the REPL, type `(mezzano.gui.filer:spawn)` and press Enter.
+    *   A new window titled "Filer" should appear.
+3.  **Navigating Directories:**
+    *   The main part of the window lists files and directories in the current path (shown at the top).
+    *   Double-click a directory to enter it.
+    *   Use the "Up" button or icon (often `[..]`) to go to the parent directory.
+4.  **Opening a File:**
+    *   To open a file (e.g., a text file), try double-clicking it. This will usually open it in the default application, which is often the text editor for text files.
+    *   For example, navigate to `/USER/` (or a similar directory if it exists) and see if there are any sample text files.
+5.  **Closing Filer:** You can close the Filer window like any other application window, typically using `M-F4` or by clicking a close button if available.
+
+## Tutorial 2: Basic Text Editing
+
+Mezzano includes a text editor with Emacs-like keybindings.
+
+1.  **Launch the Editor:**
+    *   **Option A: From Filer:** Navigate to a directory in Filer (see Tutorial 1), then right-click (if supported) or find a menu option to create a new text file. Or, double-click an existing text file.
+    *   **Option B: From REPL (opening a specific file):** If you know the path to a file, you might be able to open it directly. The command `(edit "filepath")` or similar might work. For example: `(edit "/USER/new-file.txt")`. (Note: The exact `edit` command may vary; check `user-manual.md`).
+    *   **Option C: From REPL (for a new buffer):** You can often open the editor with an empty buffer. Try `(mezzano.gui.editor:spawn-editor)` or simply `(edit)` in the REPL.
+2.  **Basic Text Input:**
+    *   Once the editor window is open, you can type text directly.
+    *   Navigate the cursor using arrow keys or Emacs keybindings (e.g., `C-F` for forward, `C-B` for backward, `C-N` for next line, `C-P` for previous line). See `user-manual.md` for a list of editor commands.
+3.  **Saving a File:**
+    *   Press `C-X C-S` (Ctrl+X then Ctrl+S).
+    *   If the file is new or doesn't have a path, the editor will prompt you for a location and filename at the bottom (in the "minibuffer"). Type the full path (e.g., `/USER/my-document.txt`) and press Enter.
+4.  **Saving with a New Name/Path (Save As):**
+    *   Press `C-X C-W` (Ctrl+X then Ctrl+W).
+    *   Enter the new path and filename when prompted.
+5.  **Closing the Editor:**
+    *   If you want to close just the current file buffer: `C-X k`. You might be asked to save if there are unsaved changes.
+    *   To close the editor application window: `M-F4`.
+
+## Tutorial 3: Using the REPL for Interaction
+
+The REPL (Read-Eval-Print Loop) is a powerful tool for interacting with Mezzano.
+
+1.  **Open a REPL:** Press `M-F10` (Alt + F10).
+2.  **Evaluating Lisp Expressions:**
+    *   Type any valid Common Lisp expression at the prompt and press Enter.
+    *   Examples:
+        *   `(+ 10 20)` (should return `30`)
+        *   `(format t "Hello, Mezzano!~%")` (should print the string and return `NIL`)
+        *   `(loop for i from 1 to 5 collect (* i i))` (should return `(1 4 9 16 25)`)
+3.  **Inspecting System State:**
+    *   The `(room)` function shows memory usage:
+        *   `(room)` or `(room t)` for a detailed report.
+    *   You can inspect variables or call functions related to the system. For example, to see information about the current thread (this is advanced): `(describe mezzano.supervisor::*current-thread*)`
+4.  **Using History:**
+    *   Press `M-P` (Alt+P) or Up-Arrow to recall previous commands.
+    *   Press `M-N` (Alt+N) or Down-Arrow to move to newer commands in history.
+5.  **Auto-completion:**
+    *   Start typing a symbol name (e.g., `mezzano.gui.`) and press `Tab`. The system will try to complete the name or show possible completions.
+
+## Tutorial 4: Taking a System Snapshot
+
+Snapshots save the entire state of your Mezzano system.
+
+1.  **When and Why to Take a Snapshot:**
+    *   Before shutting down your VM to save your current work and window layout.
+    *   After making significant configuration changes.
+    *   Periodically, as a backup of your current session.
+2.  **Ensure No Critical Operations are Running:** While snapshotting is generally safe, it's good practice to ensure no disk-intensive or highly stateful operations are in mid-process if avoidable.
+3.  **Open a REPL:** If one isn't already open, press `M-F10`.
+4.  **Execute the Snapshot Command:**
+    *   In the REPL, type `(mezzano.supervisor:snapshot)` and press Enter.
+5.  **Observe the Blinkenlights:**
+    *   A yellow light will illuminate in the status area at the top-left of the screen. This indicates that the snapshot process is active.
+    *   **Do not turn off the VM while the yellow light is on.**
+6.  **Snapshot Complete:**
+    *   Once the yellow light turns off, the snapshot is complete and saved to disk.
+7.  **Continuing or Shutting Down:**
+    *   You can continue using Mezzano.
+    *   You can now safely power off your virtual machine. When you next start Mezzano, it will boot from this most recent snapshot, restoring your session.
+
+These tutorials should help you get comfortable with some of the basic operations in Mezzano. Refer to the `user-manual.md` for more comprehensive details on all features.

--- a/doc/user-manual.md
+++ b/doc/user-manual.md
@@ -1,3 +1,9 @@
+Welcome to the Mezzano User Manual. This document provides detailed information about Mezzano's features, built-in applications, and system usage.
+
+For a guide on setting up Mezzano for the first time, please see the [Getting Started Guide](getting-started.md).
+For answers to common questions, refer to the [FAQ](faq.md).
+For step-by-step examples of common tasks, see the [Tutorials](tutorials.md).
+
 # Basic functionality
 
 `C-<key>` means to hold the control key while typing `<key>`.
@@ -148,6 +154,43 @@ the newline if the point is at the end of the line.
 `C-C C-A`      Move to the start of the current top-level form.
 
 `M-x repl`     Create an editor-based REPL.
+
+# Applications
+
+Mezzano comes with several built-in applications. These are typically launched by typing a Lisp command in the REPL. Common applications include:
+
+*   **Filer:** A graphical file manager.
+    *   Launch (example): `(mezzano.gui.filer:spawn)`
+*   **Peek:** A system information tool. View running tasks, memory, network configuration, etc.
+    *   Launch (example): `(mezzano.gui.peek:spawn)`
+*   **Editor:** A text editor with Emacs-like keybindings (detailed in "Editor commands" section).
+    *   Launch (example, new buffer): `(edit)` or `(mezzano.gui.editor:spawn-editor)`
+    *   Launch (example, specific file): `(edit "/path/to/your/file.txt")`
+*   **Memory Monitor:** Displays graphs and bitmaps of virtual and physical memory usage.
+    *   Launch (example): `(mezzano.gui.memory-monitor:spawn)`
+*   **IRC Client:** For connecting to IRC servers.
+    *   Launch (example): `(mezzano.application.irc:spawn)`
+*   **Telnet Client:** For connecting to Telnet servers.
+    *   Launch (example): `(mezzano.application.telnet:spawn)`
+*   **Mandelbrot:** A visual Mandelbrot set generator.
+    *   Launch (example): `(mezzano.mandelbrot:spawn)`
+*   **Spy:** A tool for inspecting threads and system activity.
+*   **Settings:** For configuring system settings.
+
+*Note: The exact launch commands might vary. Some applications might also be launchable from a system menu if one is available in your Mezzano version.*
+
+# Networking
+
+Mezzano supports networking with specific hardware and configurations:
+
+*   **Supported NICs:** RTL8168 and virtio-net are the primary supported network interface cards.
+    *   When using VirtualBox, the **Intel PRO/1000 MT Desktop (82540EM)** adapter (often a default for Linux VMs) is generally compatible as it can operate in a mode that Mezzano supports.
+    *   For QEMU, `virtio-net` is recommended.
+*   **Configuration:** Network settings can be viewed using the "Network" pane within the **Peek** application.
+*   **Default Network:** The default network setup is often tailored for NAT configurations in VirtualBox and QEMU.
+*   **Limitations:**
+    *   **DHCP is not currently supported.** IP addresses and network settings typically need to be configured manually or rely on the VM's NAT providing a usable static configuration.
+    *   Bridging to a real network (to get an IP on your LAN) is not supported out-of-the-box and would require manual setup.
 
 # Whole-system transparent persistence support
 


### PR DESCRIPTION
This change implements TASK-DOC-01.

It introduces a new documentation structure within the /doc directory:
- getting-started.md: A guide for new users to obtain, install, and run Mezzano for the first time.
- user-manual.md: (Renamed from quickstart.md) A detailed manual covering system interaction, keybindings, applications, networking, and other features.
- faq.md: Answers to frequently asked questions.
- tutorials.md: Step-by-step guides for common tasks.
- manual.md: Serves as a central index for all user documentation.

The README.md has also been updated to point to this new documentation hub.