### PR TITLE
Further expand application documentation

### DIFF
--- a/doc/editor-manual.md
+++ b/doc/editor-manual.md
@@ -1,0 +1,76 @@
+# Mezzano Text Editor Manual
+
+The Mezzano Text Editor provides a comprehensive environment for editing text files, particularly Lisp source code. It uses keybindings familiar to Emacs users. This manual explains the core concepts and functionalities beyond the basic keybindings listed in the main User Manual.
+
+You can typically start the editor by:
+*   Using the `(edit)` command in the REPL, optionally with a file path:
+    *   `(edit)`: Opens a new, empty buffer.
+    *   `(edit "LOCAL:>path>to>your>file.txt")`: Opens the specified file.
+*   The Filer application will also use this editor to open text-based files.
+*   The system may also refer to it as `(mezzano.gui.editor:spawn-editor)`.
+
+## Core Concepts
+
+### 1. Buffers
+
+The editor works with **buffers**. A buffer is an in-memory workspace where you edit text.
+*   When you open a file, its contents are loaded into a new buffer.
+*   You can create empty buffers (e.g., with `(edit)` without arguments).
+*   Changes you make are to the buffer in memory; they are not saved to the file on disk until you explicitly save.
+*   **Multiple Buffers:** You can have multiple buffers open simultaneously.
+    *   `C-X b` (Switch to Buffer): Prompts you to enter the name of another buffer to switch to.
+    *   `C-X C-B` (List Buffers): Displays a list of all open buffers, often in a new temporary buffer. This list usually shows buffer names, associated file paths, and modification status.
+    *   `C-X k` (Kill Buffer): Closes the current buffer. If the buffer has unsaved changes, you will typically be prompted to save them first.
+
+### 2. Files
+
+*   **Opening Files (`C-X C-F`):** This command prompts you for a file path.
+    *   If the file exists, it's read into a new buffer.
+    *   If the file does not exist, an empty buffer is created, associated with the new file name. The file itself is not created on disk until you save the buffer.
+*   **Saving Buffers (`C-X C-S`):** Saves the contents of the current buffer to its associated file.
+    *   If the buffer is not associated with a file (e.g., a new buffer), you will be prompted to enter a file path.
+*   **Save As (`C-X C-W`):** Saves the contents of the current buffer to a new file path that you specify. This changes the buffer's association to the new file path.
+
+### 3. The Point, Mark, and Region
+
+*   **Point:** This is the current position of the cursor in the buffer. Most editing commands operate relative to the point.
+*   **Mark (`C-Space`):** This command sets the "mark" at the current point. The mark is an invisible anchor.
+    *   If the mark is already active and the point is at the mark, `C-Space` deactivates the mark.
+*   **Region:** The text between the point and the mark is called the "region". Many commands operate on the current region.
+*   **Swap Point and Mark (`C-X C-X`):** Exchanges the current position of the point with the position of the mark. This is useful for adjusting the boundaries of the region.
+
+### 4. Killing and Yanking (Cut/Copy/Paste)
+
+The editor uses a "kill and yank" system similar to Emacs.
+*   **Killing Text:** Commands that delete more than one character (e.g., `C-K` for kill line, `M-D` for kill word forward, `C-W` for kill region) are "kill" commands. The killed text is stored in a conceptual "kill ring" (though the Mezzano User Manual refers to it as "last killed text," implying a simpler single-item storage).
+    *   `C-K` (Kill Line): Deletes text from the point to the end of the line. If the point is at the end of the line, it kills the newline character.
+    *   `M-D` (Kill Word Forward): Kills the word after the point.
+    *   `M-Backspace` (Kill Word Backward): Kills the word before the point.
+    *   `C-M-K` (Kill S-expression Forward): Kills the Lisp s-expression after the point.
+    *   `C-W` (Kill Region): Kills the text within the currently defined region (between point and mark).
+*   **Yanking Text (`C-Y`):** Inserts the most recently killed text at the current point. This is equivalent to "pasting."
+
+### 5. Lisp Interaction
+
+The editor has special support for Lisp code:
+*   **S-expression Movement:**
+    *   `C-M-F` (Forward S-expression): Moves the point forward over one s-expression.
+    *   `C-M-B` (Backward S-expression): Moves the point backward over one s-expression.
+*   **Evaluation:**
+    *   `C-C C-C` (Evaluate Current Top-Level Form): Evaluates the Lisp top-level form (e.g., a `defun`, `defvar`) that the point is currently in or immediately after. Results are typically shown in a REPL or minibuffer.
+*   **Navigating Forms:**
+    *   `C-C C-A` (Move to Start of Current Top-Level Form): Moves the point to the beginning of the current top-level Lisp form.
+
+### 6. Editor-Based REPL (`M-x repl`)
+
+The command `M-x repl` (Meta-X followed by typing "repl" and Enter, if it uses minibuffer prompting similar to Emacs for M-x commands) creates a REPL (Read-Eval-Print Loop) environment within or associated with the editor. This allows for interactive Lisp development without leaving the editor.
+
+## Other Notable Features (from Keybindings)
+
+*   **Basic Movement:** Arrow keys, `C-A` (beginning of line), `C-E` (end of line), `M-<` (beginning of buffer), `M->` (end of buffer), `C-V` (page down), `M-V` (page up).
+*   **Recenter Display:** `C-L` recenters the display around the point.
+*   **Redraw Screen:** `M-L` redraws the screen.
+*   **Abort Command:** `C-G` cancels the current multi-key command or operation.
+*   **Insert Literal:** `C-Q` inserts the next typed key literally, without interpreting it as a command.
+
+This manual provides an overview of the editor's conceptual model. For a full list of default keybindings, please refer to the "Editor commands" section in the main `user-manual.md`.

--- a/doc/filer-manual.md
+++ b/doc/filer-manual.md
@@ -1,0 +1,63 @@
+# Mezzano Filer Manual
+
+The Filer is Mezzano's graphical file manager. It allows you to navigate directories, view available storage hosts, and open files.
+
+## Launching Filer
+
+You can launch the Filer from the REPL using the following command:
+
+```lisp
+(mezzano.gui.filer:spawn &key initial-path width height)
+```
+
+*   `&key initial-path`: Specifies the starting directory. Defaults to the system's current default path (`*default-pathname-defaults*`).
+    *   Example: `(mezzano.gui.filer:spawn :initial-path "LOCAL:>Users>Someone>")`
+*   `&key width height`: Specifies the initial width and height of the Filer window in pixels.
+    *   Example: `(mezzano.gui.filer:spawn :width 800 :height 600)`
+
+## The Filer Window
+
+The Filer window consists of several parts:
+
+*   **Title Bar:** Displays the full path of the currently viewed directory. It also contains standard window controls like a close button. The window is resizable.
+*   **Host List:** At the top of the content area, a list of available storage hosts (e.g., `LOCAL:`, `REMOTE:`) is displayed. Clicking a host name will navigate to the root of that host.
+*   **Current Path Display:** Below the host list, the current path is displayed again.
+*   **Content Area:** This is the main part of the window, listing directories and files within the current path.
+    *   Directories are usually listed first, followed by files. Both are sorted alphabetically.
+    *   Each entry is typically preceded by an icon:
+        *   ![Up Icon](placeholder_up_icon.png) **Parent Directory (`..`):** An icon representing "up" or "parent" will be shown if you are not in the root directory of a host. Clicking this navigates one level up.
+        *   ![Folder Icon](placeholder_folder_icon.png) **Directory:** Indicates a directory.
+        *   ![File Icon](placeholder_file_icon.png) **File:** Indicates a file.
+    *   File names are color-coded based on their type to help distinguish them (e.g., Lisp source files, text files, media files). These colors are defined by the system theme.
+
+## Navigation
+
+*   **Changing Directories:** Double-click (or single-click, depending on system settings) on a directory name or its icon to enter that directory.
+*   **Going to Parent Directory:** Click the "Parent" entry (often represented by `..` or an "up" arrow icon) to navigate to the directory containing the current one.
+*   **Switching Hosts:** Click on a host name in the host list at the top (e.g., `LOCAL:`) to switch to the root directory of that host.
+
+## Opening Files
+
+To open a file, click on its name or icon. Mezzano will attempt to launch the default application associated with that file type:
+
+*   **Text Files:** (e.g., `.lisp`, `.txt`, `.md`, `.asd`) will typically open in the Mezzano Text Editor.
+*   **Image Files:** (e.g., `.png`, `.jpg`) will open in the Image Viewer (`mezzano.gui.image-viewer`).
+*   **Video Files:** (e.g., `.avi`, `.gif` - if treated as video) will open in the Media Player (`mezzano.gui.trentino`).
+*   **Audio Files:** (e.g., `.wav`) will open in the Music Player (`mezzano.gui.music-player`).
+
+The Filer determines the file type based on its extension.
+
+## Current Limitations
+
+The Mezzano Filer is primarily a navigator and file opener. As of this writing, it does **not** support features like:
+
+*   Creating new files or directories.
+*   Deleting, renaming, copying, or moving files/directories.
+*   Viewing detailed file properties (like size or modification date).
+*   Context menus (right-click functionality).
+*   Direct path input via an address bar.
+*   Bookmarks or favorite locations.
+
+For file modification tasks, you would typically use commands in the REPL or functionality within specific applications (like saving a file from the Editor).
+
+*(Note: Placeholder image links like `placeholder_up_icon.png` should be replaced with actual paths to icons if available and displayable in the documentation system, or removed if markdown doesn't support images well here.)*

--- a/doc/irc-manual.md
+++ b/doc/irc-manual.md
@@ -1,0 +1,142 @@
+# Mezzano IRC Client Manual
+
+The Mezzano IRC Client allows you to connect to Internet Relay Chat (IRC) servers, join channels, and communicate with other users.
+
+## Launching the IRC Client
+
+You can launch the IRC Client from the REPL using the following command:
+
+```lisp
+(mezzano.irc-client:spawn)
+```
+
+This will open the main IRC client window.
+
+## The IRC Client Window
+
+The client window is composed of several parts:
+
+*   **Title Bar:** Displays "IRC" or "IRC - <server_address>" when connected. It includes standard window controls like a close button and is resizable.
+*   **Display Pane:** The largest part of the window. This area shows:
+    *   Server messages (MOTD, notices, errors).
+    *   Channel messages from other users.
+    *   Private messages.
+    *   Your own messages and actions.
+    *   Status messages from the client (e.g., "Connecting to...", "Disconnected...").
+*   **Input Pane:** A single-line text entry field at the bottom of the window. This is where you type your messages and commands.
+    *   It supports line editing features (like history, using arrow keys) via `*irc-history*`.
+    *   The prompt usually indicates the current active channel, e.g., `#channel] ` or just `] ` if no channel is active.
+*   **Separator Line:** A thin line separates the display pane from the input pane.
+
+## Getting Started: Basic Workflow
+
+1.  **Set Your Nickname:** Before connecting, you need a nickname.
+    ```
+    /NICK YourDesiredNick
+    ```
+    If you don't set one, the client might use a default like "Mezzie" or fail to connect properly.
+
+2.  **Connect to a Server:**
+    ```
+    /CONNECT server_address
+    ```
+    *   `server_address` can be a hostname like `irc.libera.chat` or an IP address. You can also use `hostname:port` if the server uses a non-standard port (default is 6667).
+    *   The client knows some common servers by name. For example: `/CONNECT LiberaChat` (or just `/CONNECT Libera`). Type `/HELP` to see a list of known servers.
+    *   Upon successful connection, you will see server messages, including the Message of the Day (MOTD).
+
+3.  **Join a Channel:**
+    ```
+    /JOIN #channelname
+    ```
+    Replace `#channelname` with the actual name of the channel you wish to join (e.g., `/JOIN #mezzano`).
+    The first channel you join usually becomes your active channel.
+
+4.  **Send Messages:**
+    *   To send a message to the active channel, simply type your message in the input pane and press Enter.
+    *   Alternatively, you can use: `/SAY your message here`
+
+5.  **Switch Active Channel (if in multiple channels):**
+    ```
+    /CHAN #otherchannel
+    ```
+
+6.  **Send Private Messages:**
+    ```
+    /MSG nickname your private message
+    ```
+
+7.  **Disconnect:**
+    ```
+    /DISCONNECT Optional quit message
+    ```
+
+8.  **Quit the Client:**
+    ```
+    /QUIT Optional quit message
+    ```
+    This will also disconnect you if you are currently connected.
+
+## Commands
+
+Commands are prefixed with a forward slash (`/`). If you type text without a leading `/` and are in an active channel, it's treated as a message to that channel (`/SAY`).
+
+### Connection & Setup
+*   **`/CONNECT <server_or_address_or_known_name>`**
+    Connects to the specified IRC server. Port defaults to 6667 if not given in `address:port` format.
+    Example: `/CONNECT irc.example.com`, `/CONNECT irc.example.com:6697`, `/CONNECT LiberaChat`
+*   **`/NICK [new_nickname]`**
+    Changes your nickname to `new_nickname`. If `new_nickname` is omitted, displays your current nickname. This command should be used *before* connecting to set your initial nickname.
+*   **`/DISCONNECT [message]`**
+    Disconnects from the current server with an optional quit `message`.
+*   **`/QUIT [message]`**
+    Disconnects from the server (if connected) with an optional `message` and closes the IRC client application.
+
+### Channel Operations
+*   **`/JOIN <#channel_name> [key]`**
+    Joins the specified `channel_name`. If the channel requires a `key` (password), provide it.
+*   **`/PART [message]`**
+    Leaves the current active channel with an optional `message`.
+*   **`/CHAN <#channel_name>`**
+    Switches the active context to `channel_name`. You must have already joined this channel. Messages sent with `/SAY` or just by typing will go to this channel.
+
+### Messaging
+*   **`/SAY <message_text>`** (or just typing `<message_text>`)
+    Sends `message_text` to the current active channel.
+*   **`/MSG <target_nick_or_channel> <message_text>`**
+    Sends a private `message_text` to `target_nick_or_channel`.
+*   **`/ME <action_text>`** (also available as `/ACTION <action_text>`)
+    Sends a CTCP ACTION to the current active channel (e.g., `* YourNick performs action_text`).
+
+### Miscellaneous
+*   **`/RAW <raw_irc_message>`**
+    Sends the `raw_irc_message` directly to the server. For advanced users or debugging.
+*   **`/EVAL <lisp_code>`**
+    Evaluates the given `lisp_code` within the IRC client's Lisp environment. Results are printed to the display pane. Use with caution.
+*   **`/HELP`**
+    Displays a list of available client commands and known server names.
+
+## Server Messages
+
+The client will display various messages from the IRC server, including:
+*   Welcome messages and MOTD (Message of the Day) upon connection.
+*   Replies to your commands (e.g., topic of a channel, user lists).
+*   Error messages (e.g., nickname in use, no such channel).
+*   Notices from server administrators or services.
+*   Other users joining/parting channels, changing nicks, etc.
+
+Many numeric replies from the server are decoded into more readable forms by the client.
+
+## Initialization File
+
+The IRC client will attempt to load an initialization file from `SYS:HOME;IRC-INIT.lisp` when it starts. You can place Lisp code in this file to customize settings, define aliases, or automatically connect to servers. For example, you could set your default nickname:
+```lisp
+(setf mezzano.irc-client::*default-nick* "MyPreferredNick")
+```
+Or, more directly if the client instance is accessible or through commands:
+```lisp
+;; (This would require more complex setup, typically done by interacting with the client object itself
+;; or by sending commands after connection if the init file is loaded post-GUI setup but pre-connect logic.)
+;; For now, setting *default-nick* is the most straightforward example for an init file.
+```
+
+The init file is loaded before the main GUI loop starts, so direct GUI interactions might not be possible from it, but setting variables or defining functions that are later called by commands is feasible.Tool output for `create_file_with_block`:

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -13,9 +13,16 @@ Welcome to the Mezzano documentation. This document serves as a central hub for 
         *   Line editing and editor commands
         *   System features like snapshotting
         *   The meaning of the "blinkenlights" status indicators
-        *   Details on built-in applications (Filer, Peek, Editor, etc.)
+        *   Details on built-in applications (Mandelbrot, Spy, Settings, etc.)
         *   Networking information
         *   Using Swank for Common Lisp development
+    *   Specific Application Manuals:
+        *   [Filer Manual](filer-manual.md)
+        *   [Peek Manual](peek-manual.md)
+        *   [Text Editor Manual](editor-manual.md)
+        *   [Memory Monitor](user-manual.md#memory-monitor) (details within User Manual)
+        *   [IRC Client Manual](irc-manual.md)
+        *   [Telnet Client Manual](telnet-manual.md)
 
 *   **[Frequently Asked Questions (FAQ)](faq.md)**
     *   Find answers to common questions about hardware support, building from source, getting help, saving work, and more.

--- a/doc/peek-manual.md
+++ b/doc/peek-manual.md
@@ -1,0 +1,81 @@
+# Mezzano Peek Manual
+
+Peek is a system utility that provides a text-based view of various internal system states and information within a graphical window.
+
+## Launching Peek
+
+You can launch Peek from the REPL using the following command:
+
+```lisp
+(mezzano.gui.peek:spawn)
+```
+
+This will open the Peek window, defaulting to the Help view.
+
+## The Peek Window
+
+The Peek window has a title bar ("Peek") and standard window controls like a close button, and it is resizable. The main area of the window is a text pane where information is displayed.
+
+At the top of the text pane, a header lists the available commands:
+`Commands: Help(?) Thread(T) Memory(M) Network(N) CPU(C) Disk(D) Quit(Q)`
+
+## Using Peek - Commands
+
+Peek operates via single-character commands that switch the displayed information panel. Press the character key corresponding to the desired view.
+
+*   **`?` - Help View (`peek-help`)**
+    *   This is the default view when Peek starts.
+    *   It lists all available commands, their associated character keys, and a brief description of the information they provide.
+
+*   **`T` - Thread View (`peek-thread`)**
+    *   Displays a list of all currently active threads in the system.
+    *   For each thread, it shows:
+        *   Thread Name
+        *   State (e.g., `:RUNNING`, `:SLEEPING`, `:STOPPED`)
+        *   If a thread is `:SLEEPING`, the item it is waiting on (e.g., a lock, a mailbox) is also displayed.
+
+*   **`M` - Memory View (`peek-memory`)**
+    *   Shows detailed memory usage statistics by calling the system's `(room)` function. This typically includes:
+        *   Usage of general memory areas.
+        *   Cons area usage (for Lisp cons cells).
+        *   Pinned and wired area usage.
+        *   Function area usage.
+        *   Information on free memory, garbage collection, etc.
+    *   The output format is textual and provides a snapshot of the system's memory state.
+
+*   **`N` - Network View (`peek-network`)**
+    *   Provides a comprehensive overview of the networking subsystem:
+        *   **Network Cards (NICs):** Lists each detected network card, its MAC address, assigned IPv4 address and prefix length (if any), and detailed statistics (bytes/packets received/transmitted, errors, collisions).
+        *   **Routing Table:** Displays the system's IP routing table, showing network destinations, gateway addresses, prefix lengths, and tags.
+        *   **DNS Servers:** Lists the configured DNS servers.
+        *   **Listeners:** Shows active TCP listeners (ports open for incoming connections).
+        *   **DHCP Leases:** Displays active DHCP leases for each network interface.
+        *   **TCPv4 Connections:** Lists all active TCP version 4 connections, including local IP/port, remote IP/port, and connection state (e.g., `ESTABLISHED`, `TIME-WAIT`).
+        *   **UDPv4 Connections:** Lists active UDP version 4 connections, showing local IP/port and remote IP/port.
+
+*   **`C` - CPU View (`peek-cpu`)**
+    *   Displays detailed information about the system's CPU(s):
+        *   Lists each CPU core recognized by the Mezzano supervisor.
+        *   CPU vendor string (e.g., "GenuineIntel", "AuthenticAMD").
+        *   Maximum supported CPUID levels (standard and extended).
+        *   Processor signature: Model, Family, Stepping ID, Processor Type.
+        *   Brand Index (if applicable).
+        *   CLFLUSH line size.
+        *   Local APIC ID.
+        *   A list of detected CPU features (e.g., SSE, SSE2, MMX, AVX, NX, LM, etc.), derived from CPUID flags.
+
+*   **`D` - Disk View (`peek-disk`)**
+    *   Shows information about all storage disks recognized by the system:
+        *   Internal disk object representation and its assigned name (if any, e.g., `SDA`).
+        *   Read/write or read-only status.
+        *   Sector size in bytes.
+        *   Total disk size in sectors and in octets (bytes).
+        *   Indicates if a disk is currently used as the paging disk.
+
+*   **`Q` - Quit**
+    *   Closes the Peek application window. This can also be achieved by clicking the window's close button.
+
+*   **`Space` - Refresh**
+    *   Pressing the Space bar will refresh the content of the currently active view, re-querying the system for the latest information.
+
+Peek is a valuable tool for developers and users to inspect the live state of a Mezzano system. Due to the textual nature of its output, you might need to resize the window to see all information clearly, especially for wider outputs like the Network or CPU views.

--- a/doc/telnet-manual.md
+++ b/doc/telnet-manual.md
@@ -1,0 +1,77 @@
+# Mezzano Telnet Client Manual
+
+The Mezzano Telnet Client allows you to connect to remote servers using the Telnet protocol. It provides a terminal interface to interact with these servers.
+
+## Launching the Telnet Client
+
+You can launch the Telnet client from the REPL using the `spawn` function:
+
+```lisp
+(mezzano.telnet:spawn &key server port terminal-type width height)
+```
+
+**Parameters:**
+
+*   `&key server` (String): The hostname or IP address of the Telnet server to connect to.
+    *   If an empty string (default) or not provided, the client will prompt you to enter a server address in its terminal window upon launch.
+    *   Example: `:server "nethack.alt.org"`
+*   `&key port` (Integer): The port number on the server. Defaults to `23`.
+    *   Example: `:port 2323`
+*   `&key terminal-type` (String): The terminal type string to announce to the server (e.g., for `TERM` environment variable). Defaults to `"xterm-color"`.
+    *   Example: `:terminal-type "vt100"`
+*   `&key width` (Integer): The initial width of the terminal display in characters. Defaults to `80`.
+*   `&key height` (Integer): The initial height of the terminal display in characters. Defaults to `24`.
+
+**Examples:**
+
+*   Launch and prompt for server: `(mezzano.telnet:spawn)`
+*   Connect directly to a server: `(mezzano.telnet:spawn :server "mybbs.example.com")`
+*   Connect to a server on a specific port with a larger terminal:
+    `(mezzano.telnet:spawn :server "server.example.org" :port 7777 :width 100 :height 40)`
+
+## The Telnet Window
+
+*   The client opens a graphical window typically titled "Telnet" or "Telnet - <server_address>:<port>" once connected.
+*   The window contains an embedded terminal display, powered by an xterm-like terminal emulator. This handles character display, colors (if negotiated and supported by the server/application), cursor positioning, and basic terminal escape codes.
+*   The window is resizable. When resized, the terminal dimensions (character rows/columns) will adjust, and if the server supports NAWS (Negotiate About Window Size), the new dimensions are sent to the server.
+*   Standard window controls, like a close button, are present.
+
+## Connecting to a Server
+
+If you launch the client without specifying a `server` argument, it will first display a list of "Known servers" (shortcuts defined within the client, like "nao" for "nethack.alt.org") and then prompt you with:
+```
+Server>
+```
+Type the hostname or IP address of the server you wish to connect to and press Enter.
+
+Once a server and port are determined (either from arguments or user input), the client attempts to establish a connection.
+
+## Interaction
+
+*   **Sending Data:** Characters you type into the Telnet window are sent to the remote server.
+*   **Receiving Data:** Data received from the server is displayed in the terminal window. This includes text output from remote applications, prompts, etc.
+*   **Terminal Emulation:** The client relies on its underlying xterm widget to interpret most terminal control codes sent by the server for formatting output, moving the cursor, etc.
+*   **Line Endings:** The client handles CR (Carriage Return) and CR NUL sequences appropriately for display.
+
+## Telnet Protocol Features
+
+The client implements several aspects of the Telnet protocol:
+
+*   **Command Interpretation (IAC):** Correctly processes Interpret As Command (IAC) sequences.
+*   **Option Negotiation:** It will attempt to negotiate the following options with the server:
+    *   **Suppress Go-Ahead (`+option-suppress-go-ahead+`):** The client indicates it WILL suppress go-ahead, and prefers the server to DO the same.
+    *   **Terminal Type (`+option-terminal-type+`):** If the server requests (DO), the client will respond with its configured terminal type (e.g., "xterm-color").
+    *   **Window Size (NAWS - `+option-window-size+`):** The client indicates it WILL send window size information. If the server agrees (DO), the client will send updates when its window is resized.
+*   It will generally refuse (WONT) other options it doesn't explicitly support.
+
+## Disconnecting
+
+*   To disconnect from the server, you typically use the logout command of the remote system you are connected to (e.g., `exit`, `logout`, `bye`).
+*   If the server closes the connection, the Telnet client will display a "Disconnected from server" message.
+*   Closing the Telnet window using the window's close button will also terminate the connection and the application.
+
+## Notes and Limitations
+
+*   **Character Encoding:** The documentation notes a FIXME regarding UTF-8 translation. While Mezzano itself handles Unicode, the Telnet client's direct byte handling for network I/O and passthrough to the xterm widget might have implications for full UTF-8 correctness in all scenarios with all servers.
+*   **Advanced Telnet Options:** The client supports common options like terminal type and window size but may not support more esoteric Telnet options.
+*   The actual terminal emulation capabilities (e.g., specific escape sequences supported, color fidelity) depend on the `mezzano.gui.xterm:xterm-terminal` component.

--- a/doc/user-manual.md
+++ b/doc/user-manual.md
@@ -73,109 +73,97 @@ The line editor supports most standard line navigation and editing commands.
 
 `Tab`          Cycle through completions for the current symbol.
 
-# Editor commands
+# Editor
 
-The editor mostly follows Emacs conventions.
+Mezzano includes a powerful text editor with Emacs-like keybindings, suitable for general text editing and Lisp development. For a detailed explanation of its features, concepts (buffers, files, regions, kill/yank, Lisp interaction), and a full guide, please see the [Mezzano Text Editor Manual](editor-manual.md).
 
-`C-F`          Move forward (right) one character, also bound to Right-Arrow.
+Launch the editor using the `(edit)` command or `(mezzano.gui.editor:spawn-editor)`:
+*   `(edit)` or `(mezzano.gui.editor:spawn-editor)`: Opens a new, empty buffer.
+*   `(edit "path/to/file")`: Opens the specified file.
 
-`C-B`          Move backward (left) one character, also bound to Left-Arrow.
+## Common Editor Keybindings
 
-`C-N`          Move to the next line (down), also bound to Down-Arrow.
+Here is a summary of common keybindings. Refer to the [Editor Manual](editor-manual.md) for more context.
 
-`C-P`          Move to the previous line (up), also bound to Up-Arrow.
+**Movement:**
+`C-F` / `Right-Arrow`: Forward character
+`C-B` / `Left-Arrow`: Backward character
+`C-N` / `Down-Arrow`: Next line
+`C-P` / `Up-Arrow`: Previous line
+`C-A` / `Home`: Beginning of line
+`C-E` / `End`: End of line
+`M-F` / `M-Right-Arrow`: Forward word
+`M-B` / `M-Left-Arrow`: Backward word
+`M-<` / `Home` (sometimes): Beginning of buffer
+`M->` / `End` (sometimes): End of buffer
+`C-V` / `Page-Down`: Page down
+`M-V` / `Page-Up`: Page up
+`C-M-F`: Forward s-expression
+`C-M-B`: Backward s-expression
+`C-C C-A`: Move to start of current top-level Lisp form
 
-`C-A`          Move to beginning of line.
+**Editing (Deleting/Killing):**
+`C-D` / `Delete`: Delete next character
+`Backspace`: Delete previous character
+`M-D`: Kill next word
+`M-Backspace`: Kill previous word
+`C-K`: Kill from cursor to end of line (or newline if at EOL)
+`C-M-K`: Kill next s-expression
+`C-W`: Kill region (between point and mark)
 
-`C-E`          Move to end of line.
+**Yanking (Pasting):**
+`C-Y`: Yank last killed text
 
-`M-<`          Move to the beginning of the buffer, also bound to Home.
+**Mark and Region:**
+`C-Space`: Set mark / Deactivate mark
+`C-X C-X`: Swap point and mark
 
-`M->`          Move to the end of the buffer, also bound to End.
+**File Operations:**
+`C-X C-F`: Open or create a file
+`C-X C-S`: Save current buffer
+`C-X C-W`: Save buffer with new path
 
-`C-V`          Move the point to the bottom of the screen and recenter, also bound to Page-Down.
+**Buffer Management:**
+`C-X b`: Switch to a different buffer
+`C-X C-B`: List buffers
+`C-X k`: Close (kill) current buffer
 
-`M-V`          Move the point to the top of the screen and recenter, also
+**Lisp Interaction:**
+`C-C C-C`: Evaluate current top-level Lisp form
+`M-x repl`: Create an editor-based REPL
 
-bound to Page-Up.
-
-`M-F`          Move forward one word.
-
-`M-B`          Move backward one word.
-
-`C-M-F`        Move forward one s-expression.
-
-`C-M-B`        Move backward one s-expression.
-
-`C-D`          Delete the next character, also bound to Delete.
-
-`Backspace`    Delete the previous character.
-
-`M-D`          Kill the next word.
-
-`M-Backspace`  Kill the previous word.
-
-`C-K`          Kill characters from the point to the end of the line, or kill
-
-the newline if the point is at the end of the line.
-
-`C-M-K`        Kill the next s-expression forward.
-
-`C-W`          Kill the area between the point and the mark.
-
-`C-Y`          Yank the last killed text back into the buffer at the point.
-
-`C-L`          Recenter the display on the point.
-
-`M-L`          Redraw the screen.
-
-`C-Q`          Insert the next key typed without intepretting it as a command.
-
-`C-Space`      If the point is at the mark and the mark is active, deactivate the mark. Otherwise, activate the mark and move it to the point.
-
-`C-X C-X`      Swap the point and the mark.
-
-`C-X C-F`      Open or create a file.
-
-`C-X C-S`      Save the current buffer. If the buffer has no path, you will be prompted for a location to save it.
-
-`C-X C-W`      Save the current buffer with a new path.
-
-`C-X b`        Switch to a different buffer.
-
-`C-X C-B`      List buffers.
-
-`C-X k`        Close an open buffer.
-
-`C-G`          Abort the current command.
-
-`C-C C-C`      Evaluate the current top-level form.
-
-`C-C C-A`      Move to the start of the current top-level form.
-
-`M-x repl`     Create an editor-based REPL.
+**Miscellaneous:**
+`C-L`: Recenter display
+`M-L`: Redraw screen
+`C-Q`: Insert next key typed literally
+`C-G`: Abort current command
 
 # Applications
 
 Mezzano comes with several built-in applications. These are typically launched by typing a Lisp command in the REPL. Common applications include:
 
-*   **Filer:** A graphical file manager.
+*   **Filer:** A graphical file manager. See the [Filer Manual](filer-manual.md) for detailed information.
     *   Launch (example): `(mezzano.gui.filer:spawn)`
-*   **Peek:** A system information tool. View running tasks, memory, network configuration, etc.
+*   **Peek:** A system information tool. View running tasks, memory, network configuration, etc. See the [Peek Manual](peek-manual.md) for detailed information.
     *   Launch (example): `(mezzano.gui.peek:spawn)`
-*   **Editor:** A text editor with Emacs-like keybindings (detailed in "Editor commands" section).
+*   **Editor:** A text editor with Emacs-like keybindings. See the [Editor Manual](editor-manual.md) for full details.
     *   Launch (example, new buffer): `(edit)` or `(mezzano.gui.editor:spawn-editor)`
     *   Launch (example, specific file): `(edit "/path/to/your/file.txt")`
 *   **Memory Monitor:** Displays graphs and bitmaps of virtual and physical memory usage.
     *   Launch (example): `(mezzano.gui.memory-monitor:spawn)`
-*   **IRC Client:** For connecting to IRC servers.
+*   **IRC Client:** For connecting to IRC servers. See the [IRC Client Manual](irc-manual.md) for detailed information.
     *   Launch (example): `(mezzano.application.irc:spawn)`
-*   **Telnet Client:** For connecting to Telnet servers.
+*   **Telnet Client:** For connecting to Telnet servers. See the [Telnet Client Manual](telnet-manual.md) for detailed information.
     *   Launch (example): `(mezzano.application.telnet:spawn)`
-*   **Mandelbrot:** A visual Mandelbrot set generator.
-    *   Launch (example): `(mezzano.mandelbrot:spawn)`
-*   **Spy:** A tool for inspecting threads and system activity.
-*   **Settings:** For configuring system settings.
+*   **Mandelbrot:** `(mezzano.mandelbrot:spawn &optional width height)`
+    This application renders a colourful visualization of the Mandelbrot set or a Julia set. The window displays the fractal, which is drawn progressively.
+    *   Press `M` to view the Mandelbrot set (default).
+    *   Press `J` to switch to viewing a predefined Julia set.
+    The fractal's colours will vary subtly with each full redraw as they are influenced by the current time. The window is resizable, and resizing will trigger a recalculation and redraw of the fractal.
+*   **Spy:** `(mezzano.gui.spy:spawn)`
+    A developer utility for inspecting the internal state of the GUI compositor and input systems. The Spy window displays a text-based stream of information that updates periodically. This includes current mouse coordinates and button states, the window under the mouse, active drag operations, the current system keymap, keyboard modifier states, a list of all windows, and other low-level GUI details. This tool is primarily useful for debugging GUI behavior.
+*   **Settings:** `(mezzano.gui.settings:spawn)`
+    This application allows you to configure basic system settings. Currently, its primary function is to **change the system keyboard layout (keymap)**. Upon launching, it displays a list of available keymaps (e.g., En-GB, En-US, German). Clicking on one of these buttons immediately switches the system's active keymap to the selected layout. The currently active keymap button is typically highlighted.
 
 *Note: The exact launch commands might vary. Some applications might also be launchable from a system menu if one is available in your Mezzano version.*
 
@@ -224,31 +212,53 @@ From left to right:
 
 # Memory Monitor
 
-The memory monitor has two modes. The first mode displays a graph of virtual
-memory usage. The second mode displays a bitmap indicating how each page
-of physical memory is used, with colours indicating type.
+The Memory Monitor application provides a visual display of physical and virtual memory usage. It helps in understanding how memory is allocated and utilized by the system.
 
-Virtual Memory Graph Colours:
------
+**Launch Command:** `(mezzano.gui.memory-monitor:spawn &optional width height)`
 
-`Dark Blue`    General area % usage.
+The Memory Monitor has two main modes, which can be switched using keyboard shortcuts or by clicking tabs at the top of the window:
+*   **Graphs Mode (Press 'G' or click "Graphs" tab):** This is often the default mode. It displays scrolling line graphs for various virtual memory metrics over time.
+*   **Physical Visualizer Mode (Press 'P' or click "Physical Visualizer" tab):** This mode displays a bitmap where each pixel or small block represents a page (or group of pages) of physical memory, colored according to its current usage type.
 
-`Purple`       General area bytes allocated and committed.
+Press `Space` to refresh the current view.
 
-`Green`        Cons area % usage.
+## Graphs Mode Details
 
-`Lime Green`   Cons area bytes allocated and committed.
+In Graphs Mode, several metrics are tracked:
 
-`Red`          Pinned area % usage.
+*   **General Area Usage (%):** Percentage of the general-purpose memory area currently in use.
+*   **General Area Bytes Allocated:** Total bytes allocated in the general area (autoscaled graph).
+*   **General Area Bytes Committed:** Total bytes committed in the general area (autoscaled graph).
+*   **Cons Area Usage (%):** Percentage of the memory area dedicated to Lisp cons cells currently in use.
+*   **Cons Area Bytes Allocated:** Total bytes allocated in the cons area (autoscaled graph).
+*   **Cons Area Bytes Committed:** Total bytes committed in the cons area (autoscaled graph).
+*   **Pinned Area Usage (%):** Percentage of memory pinned for specific purposes (e.g., DMA).
+*   **Wired Area Usage (%):** Percentage of memory wired down (cannot be paged out).
+*   **Function Area Usage (%):** Percentage of memory used for compiled function code.
+*   **Wired Function Area Usage (%):** Percentage of function area memory that is wired.
 
-`Hot Pink`     Wired area % usage.
+**Graph Colours:**
+The colours for the lines in the Graphs Mode correspond to specific metrics:
 
-`Brown`        Function area % usage.
+*   **General Area % Usage:** `Dark Blue` (controlled by `theme:*memory-monitor-general-area-usage*`)
+*   **General Area Bytes Allocated:** `Purple` (controlled by `theme:*memory-monitor-general-area-alloc*`)
+*   **General Area Bytes Committed:** (controlled by `theme:*memory-monitor-general-area-commit*`)
+*   **Cons Area % Usage:** `Green` (controlled by `theme:*memory-monitor-cons-area-usage*`)
+*   **Cons Area Bytes Allocated:** `Lime Green` (controlled by `theme:*memory-monitor-cons-area-alloc*`)
+*   **Cons Area Bytes Committed:** (controlled by `theme:*memory-monitor-cons-area-commit*`)
+*   **Pinned Area % Usage:** `Red` (controlled by `theme:*memory-monitor-pinned-area-usage*`)
+*   **Wired Area % Usage:** `Hot Pink` (controlled by `theme:*memory-monitor-wired-area-usage*`)
+*   **Function Area % Usage:** `Brown` (controlled by `theme:*memory-monitor-function-area-usage*`)
+*   **Wired Function Area % Usage:** `Lilac` (controlled by `theme:*memory-monitor-wired-function-area-usage*`)
 
-`Lilac`        Wired Function area % usage.
+The graph background is typically a dark color (controlled by `theme:*memory-monitor-graph-background*`), and a vertical tracker line indicates the current sampling point (controlled by `theme:*memory-monitor-graph-tracker*`).
 
-Physical Memory Colours:
------
+## Physical Visualizer Mode Details
+
+This mode displays a bitmap indicating how each page of physical memory is used.
+
+**Physical Memory Colours:**
+These colours indicate the status of physical memory pages:
 
 `Blue`         Free memory.
 


### PR DESCRIPTION
This commit significantly enhances the documentation for several Mezzano applications as part of the ongoing documentation effort (Sprint 2 focus).

New dedicated manuals have been created for:
- Filer (`doc/filer-manual.md`)
- Peek (`doc/peek-manual.md`)
- IRC Client (`doc/irc-manual.md`)
- Telnet Client (`doc/telnet-manual.md`)
- Text Editor (`doc/editor-manual.md`): Explains concepts like buffers, mark/region, kill/yank, etc., based on the features implied by its existing keybinding list.

The main `doc/user-manual.md` has been updated to:
- Link to these new dedicated manuals.
- Include more detailed descriptions for Mandelbrot, Spy, and Settings applications directly within it.
- Provide an improved and more detailed section for the Memory Monitor, covering its modes and graph interpretations.

The `doc/manual.md` index file has also been updated to reflect this new structure and link to the new application manuals.